### PR TITLE
fix failing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ bin/*
 .idea
 helper.rb
 test/integration/data_bags/
+
+# build output
+metadata.json

--- a/spec/unit/recipes/test_create_pool_spec.rb
+++ b/spec/unit/recipes/test_create_pool_spec.rb
@@ -2,11 +2,14 @@ require 'spec_helper'
 require 'f5/icontrol'
 require_relative '../../../libraries/chef_f5'
 require_relative '../../../libraries/credentials'
+require_relative '../../../libraries/gem_helper'
 
 describe 'f5_test::test_create_pool' do
   let(:api) { double('F5::Icontrol') }
 
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04', step_into: ['f5_pool']).converge(described_recipe) }
+  let(:chef_run) { 
+    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04', step_into: ['f5_pool']).converge(described_recipe) 
+  }
 
   before do
     allow(F5::Icontrol::API).to receive(:new) { api }
@@ -16,9 +19,9 @@ describe 'f5_test::test_create_pool' do
 
   context 'managing the pool' do
     before do
-      allow_any_instance_of(ChefF5).to receive(:pool_is_missing_node?).and_return(false)
-      allow_any_instance_of(ChefF5).to receive(:node_is_missing?).and_return(false)
-      allow_any_instance_of(ChefF5).to receive(:pool_is_missing_monitor?).and_return(false)
+      allow_any_instance_of(ChefF5::Client).to receive(:pool_is_missing_node?).and_return(false)
+      allow_any_instance_of(ChefF5::Client).to receive(:node_is_missing?).and_return(false)
+      allow_any_instance_of(ChefF5::Client).to receive(:pool_is_missing_monitor?).and_return(false)
     end
 
     context 'the pool does not exist' do
@@ -58,9 +61,9 @@ describe 'f5_test::test_create_pool' do
     let (:node) { double }
 
     before do
-      allow_any_instance_of(ChefF5).to receive(:pool_is_missing?).and_return(false)
-      allow_any_instance_of(ChefF5).to receive(:pool_is_missing_node?).and_return(false)
-      allow_any_instance_of(ChefF5).to receive(:pool_is_missing_monitor?).and_return(false)
+      allow_any_instance_of(ChefF5::Client).to receive(:pool_is_missing?).and_return(false)
+      allow_any_instance_of(ChefF5::Client).to receive(:pool_is_missing_node?).and_return(false)
+      allow_any_instance_of(ChefF5::Client).to receive(:pool_is_missing_monitor?).and_return(false)
       allow(api).to receive_message_chain('LocalLB.NodeAddressV2') { node }
     end
 
@@ -96,8 +99,8 @@ describe 'f5_test::test_create_pool' do
     let (:node) { double }
 
     before do
-      allow_any_instance_of(ChefF5).to receive(:pool_is_missing?).and_return(false)
-      allow_any_instance_of(ChefF5).to receive(:pool_is_missing_node?).and_return(false)
+      allow_any_instance_of(ChefF5::Client).to receive(:pool_is_missing?).and_return(false)
+      allow_any_instance_of(ChefF5::Client).to receive(:pool_is_missing_node?).and_return(false)
       allow(api).to receive_message_chain('LocalLB.Pool') { pool }
       allow(api).to receive_message_chain('LocalLB.NodeAddressV2') { node }
       expect(node).to receive(:get_list) {
@@ -109,7 +112,7 @@ describe 'f5_test::test_create_pool' do
     end
     context 'the monitor is already on assigned to the pool' do
       before do
-        allow_any_instance_of(ChefF5).to receive(:pool_is_missing_monitor?).and_return(false)
+        allow_any_instance_of(ChefF5::Client).to receive(:pool_is_missing_monitor?).and_return(false)
       end
       it 'doesnt add the monitor to the pool' do
         expect(pool).to_not receive(:set_monitor_association)
@@ -119,7 +122,7 @@ describe 'f5_test::test_create_pool' do
 
     context 'the monitor isnt assigned to the pool' do
       before do
-        allow_any_instance_of(ChefF5).to receive(:pool_is_missing_monitor?).and_return(true)
+        allow_any_instance_of(ChefF5::Client).to receive(:pool_is_missing_monitor?).and_return(true)
       end
       it 'adds the monitor to the pool' do
         expect(pool).to receive(:set_monitor_association)


### PR DESCRIPTION
Add in a missing `require_relative` link for `gem_helper.rb` (similar to [those added](https://github.com/swalberg/chef-f5/commit/2ca63b7394f8979414fc23fa6c2d06bf73bbf95f#diff-a04bc199bd980261bd1977b294749023R3) in 2ca63b73)

Also in PR #5 `ChefF5` was changed from a class name to a module name and the methods previously living in `ChefF5` were [moved to live inside a new class](https://github.com/swalberg/chef-f5/pull/5/files#diff-3c5b2d6e016fea7303f423930a284056R2) called `ChefF5::Client`.

This broke the mocking which was set up in the spec tests (e.g. [`test_create_pool_spec.rb`](https://github.com/swalberg/chef-f5/blob/a7d64588ae2553af472a816814fe030e6da3cbcc/spec/unit/recipes/test_create_pool_spec.rb#L19-L21)):
```
      allow_any_instance_of(ChefF5).to receive(:pool_is_missing_node?).and_return(false)
      allow_any_instance_of(ChefF5).to receive(:node_is_missing?).and_return(false)
      allow_any_instance_of(ChefF5).to receive(:pool_is_missing_monitor?).and_return(false)
```

With those (and similar) expectations now targeting the wrong class all 7 tests were failing with errors about unmocked call chains on the doubles:
```
  1) f5_test::test_create_pool managing the pool the pool does not exist creates the pool
     Failure/Error: ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04', step_into: ['f5_pool']).converge(described_recipe)
       #<Double (anonymous)> received unexpected message :NodeAddressV2 with (no args)
     # ./libraries/chef_f5.rb:10:in `node_is_missing?'
     # /var/folders/q7/rcn_34yx7pvb0n7sch3flr5c0000gn/T/d20170824-38667-1n06w2a/cookbooks/f5/resources/pool.rb:21:in `block in class_from_file'
     # ./spec/unit/recipes/test_create_pool_spec.rb:11:in `block (2 levels) in <top (required)>'
     # ./spec/unit/recipes/test_create_pool_spec.rb:41:in `block (4 levels) in <top (required)>'
```

This PR adjusts the mocking in the rspec contexts to correctly target the new `ChefF5::Client` class and all 7 specs are passing again.
