### PR TITLE
add basic custom matchers for `f5_pool` and `f5_vip`

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,6 +26,8 @@ suites:
       - recipe[f5_test::test_create_pool]
       - recipe[f5_test::test_create_vip]
     attributes:
+      fqdn: local.kitchen.node
+      ipaddress: 127.0.0.1
       f5:
         credentials:
           default:

--- a/libraries/gem_helper.rb
+++ b/libraries/gem_helper.rb
@@ -1,8 +1,6 @@
 module ChefF5
   module GemHelper
     def load_f5_gem
-      require 'f5/icontrol'
-    rescue LoadError
       install_f5_gem
       require 'f5/icontrol'
     end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,9 @@
+if defined?(ChefSpec)
+  def create_f5_vip(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new('f5_vip', 'create', resource_name)
+  end
+
+  def create_f5_pool(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new('f5_pool', 'create', resource_name)
+  end
+end

--- a/spec/unit/recipes/test_create_pool_spec.rb
+++ b/spec/unit/recipes/test_create_pool_spec.rb
@@ -34,7 +34,13 @@ describe 'f5_test::test_create_pool' do
 
       it 'creates the pool' do
         expect(api).to receive_message_chain('LocalLB', 'Pool', 'create_v2') { true }
-        chef_run
+
+        expect(chef_run).to create_f5_pool('reallybasic').with(
+          ip: '10.0.0.2',
+          host: 'fauxhai.local',
+          port: 80,
+          monitor: 'test-monitor'
+        )
       end
     end
 

--- a/spec/unit/recipes/test_create_vip_spec.rb
+++ b/spec/unit/recipes/test_create_vip_spec.rb
@@ -63,7 +63,13 @@ describe 'f5_test::test_create_vip' do
 
         expect(server_api).to receive(:create)
         expect(server_api).to receive(:set_type)
-        chef_run
+
+        expect(chef_run).to create_f5_vip('myvip').with(
+          address: '86.75.30.9',
+          port: '80',
+          protocol: 'PROTOCOL_TCP',
+          pool: 'reallybasic'
+        )
       end
 
       it 'sets the pool' do


### PR DESCRIPTION
- also resolves an issue whereby changes to the `node['f5']['gem_version']` attribute would not be respected because the previous version of the `gem_helper` ensured that the gem was present but only respected the specified version on first install.

- with this PR the `chef_gem` resource is added each time, so that a new `gem_version` attribute will trigger chef to pull down and install the new version during the compile phase so that it is available to any consumers who need it.