### PR TITLE
os[windows] was not included in the list; let's see what we need

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,6 +19,12 @@ platforms:
   - name: opensuse-leap-42.2
   - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: windows-2012-r2
+    driver_config:
+      box: mwrock/Windows2012R2
+  - name: windows-2016
+    driver_config:
+      box: mwrock/Windows2016
 
 suites:
   - name: default

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A set of resources for managing F5 load balancers. Currently a WIP, but it will 
 
 - RHEL/Fedora and derivatives
 - Debian/Ubuntu and derivatives
+- Windows [2012.R2, 2016]
 
 ### Chef
 

--- a/libraries/gem_helper.rb
+++ b/libraries/gem_helper.rb
@@ -15,7 +15,7 @@ module ChefF5
 
       package packages do
         action :nothing
-      end.run_action(:install)
+      end.run_action(:install) unless packages.nil?
 
       chef_gem 'f5-icontrol' do
         compile_time true


### PR DESCRIPTION
## Problem

```
    ArgumentError
    ---------------
    You must supply a name when declaring a package resource.

    Cookbook Trace
    ----------------
    c:/chef/cache/cookbooks/f5/libraries/gem_helper.rb:16:in 'install_f5_gem'
    c:/chef/cache/cookbooks/f5/libraries/gem_helper.rb:4:in 'install_f5_gem'
    c:/chef/cache/cookbooks/f5/resources/pool:13:in 'block in class_from_file'
```

## Root cause

When converging and using `f5` resources on a node where 'node['platform_family']` was not one of:
- `rhel`
- `fedora`
- `amazon`
- `suse`
- `debian`
this error would occur because `packages` would be `nil` at [line 16](https://github.com/swalberg/chef-f5/blob/2b57b5f2e1a6ac2ab96d28f305363f73f0f44a23/libraries/gem_helper.rb#L16) (due to [the `when` case statement excluding alternative cases](https://github.com/swalberg/chef-f5/blob/2b57b5f2e1a6ac2ab96d28f305363f73f0f44a23/libraries/gem_helper.rb#L9-L14), such as `windows`)

## Fix

- ensure that we only call that `package` resource when we have `packages` to install.

## Test cases

- successfully converged a recipe using the `f5_pool` and `f5_vip` resources on a Windows 2012R2 instance in test kitchen; it turns out this referencing this cookbook is sufficient to install the required dependencies to use these resources on a Windows node.