### PR TITLE
Support using an FQDN for the VIP (experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ end
 
 # Creates the VIP if missing
 f5_vip 'myvip' do
-  address 'vipaddress'
+  address 'vipaddress' # IPv4 or FQDN, see below
   port 'vipport'
   protocol 'protocol' # TCP default
   pool 'mypool'
@@ -90,6 +90,13 @@ end
 ```
 
 See the documentation for [LocalLB::LBMethod](https://devcentral.f5.com/wiki/iControl.LocalLB__LBMethod.ashx) and [protocol](https://devcentral.f5.com/wiki/iControl.Common__ProtocolType.ashx).
+
+#### Using DNS for the name
+
+This is an **experimental feature**. Some of the corner cases might not work :)
+
+If you pass a FQDN to the VIP's address, this resource will attempt to resolve the name through DNS. If a match is found, the first address returned is used for the VIP. If no match is found, the resource will not be processed.
+
 
 #### Manging node enabled status through node attributes
 

--- a/libraries/dns_lookup.rb
+++ b/libraries/dns_lookup.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+
+require 'resolv'
+
+# Uses the core Ruby library to do a lookup on a host and return the address
+# plus if it actually exists or not
+class DNSLookup
+  def initialize(host)
+    @host = host
+  end
+
+  def exists?
+    !lookup.empty?
+  end
+
+  def address
+    return nil unless exists?
+    lookup.first.address.to_s
+  end
+
+  private
+
+  def lookup
+    @lookup ||= Resolv::DNS.new.getresources(@host, Resolv::DNS::Resource::IN::A)
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email 'sean@ertw.com'
 license          'MIT'
 description      'Resources for managing an F5 BigIP load balancer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.6'
+version          '0.4.0'
 
-%w(ubuntu debian redhat centos suse opensuse opensuseleap scientific oracle amazon).each do |os|
+%w(ubuntu debian redhat centos suse opensuse opensuseleap scientific oracle amazon windows).each do |os|
   supports os
 end
 

--- a/spec/libraries/dns_lookup_spec.rb
+++ b/spec/libraries/dns_lookup_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require './libraries/dns_lookup'
+
+describe DNSLookup do
+  let(:invalid_name) { 'xxx.yyy.qww' }
+  let(:valid_name) { 'github.com' }
+
+  describe '#exists?' do
+    it 'exists' do
+      expect(described_class.new(valid_name).exists?).to be_truthy
+    end
+
+    it 'does not exist' do
+      expect(described_class.new(invalid_name).exists?).to be_falsey
+    end
+  end
+
+  describe '#address' do
+    it 'returns nil on an invalid address' do
+      expect(described_class.new(invalid_name).address).to be_nil
+    end
+
+    it 'returns an address when its valid' do
+      expect(described_class.new(valid_name).address).to match /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
+    end
+  end
+end

--- a/spec/unit/recipes/test_create_vip_name_spec.rb
+++ b/spec/unit/recipes/test_create_vip_name_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+require 'f5/icontrol'
+require_relative '../../../libraries/chef_f5'
+require_relative '../../../libraries/credentials'
+require_relative '../../../libraries/dns_lookup'
+require_relative '../../../libraries/gem_helper'
+
+describe 'f5_test::test_create_vip_name' do
+  let(:api) { double('F5::Icontrol') }
+  let(:server_api) { double('F5::Icontrol::LocalLB::VirtualServer') }
+
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(
+      platform: 'centos',
+      version: '7.2.1511',
+      step_into: ['f5_vip']
+    ) do |node|
+      node.normal[:f5][:credentials][:default] = {
+        host: '1.2.3.4',
+        username: 'api',
+        password: 'testing'
+      }
+    end.converge(described_recipe)
+  end
+
+  before do
+    allow(F5::Icontrol::API).to receive(:new) { api }
+
+    allow(api)
+      .to receive_message_chain('LocalLB.VirtualServer') { server_api }
+
+    allow_any_instance_of(Chef::RunContext::CookbookCompiler)
+      .to receive(:compile_libraries).and_return(true)
+
+    stub_data_bag_item('f5', 'default')
+      .and_return(host: '1.2.3.4', username: 'api', password: 'testing')
+  end
+
+  context 'when managing the vip' do
+    before do
+      # these vips have no profiles
+      allow(server_api).to receive(:get_profile) {
+        { item: [[]] }
+      }
+
+      # these vips have their SAT set to None
+      allow(server_api)
+        .to receive(:get_source_address_translation_type) {
+          { item: [
+              F5::Icontrol::LocalLB::VirtualServer::SourceAddressTranslationType::SRC_TRANS_NONE
+          ]}}
+    end
+
+    context 'and the name hasnt been created yet' do
+      it 'skips all the work' do
+        allow_any_instance_of(DNSLookup)
+          .to receive(:address).and_return(nil)
+
+        expect(server_api).to_not receive(:create)
+
+        chef_run
+      end
+    end
+
+    context 'and the vip does not exist' do
+      before do
+        allow(server_api).to receive(:get_list) {
+          { item: [] }
+        }
+      end
+
+      it 'creates the vip' do
+        allow_any_instance_of(ChefF5::Client)
+          .to receive(:vip_default_pool).and_return('reallybasic')
+
+        allow_any_instance_of(DNSLookup)
+          .to receive(:address).and_return('90.2.1.0')
+
+        expect(server_api).to receive(:create) do |args|
+          expect(args[:definitions][:item][:address]).to eq '90.2.1.0'
+        end
+
+        expect(server_api).to receive(:set_type)
+
+        expect(chef_run).to create_f5_vip('myvip').with(
+          address: 'github.com',
+          port: '80',
+          protocol: 'PROTOCOL_TCP',
+          pool: 'reallybasic'
+        )
+      end
+    end
+
+    context 'and the vip already exists' do
+      before do
+        allow(server_api).to receive(:get_list) {
+          { item: ['/Common/myvip'] }
+        }
+      end
+
+      it 'does not create the vip' do
+        allow_any_instance_of(ChefF5::Client).to receive(:vip_default_pool)
+        allow_any_instance_of(ChefF5::Client).to receive(:set_vip_pool)
+        chef_run
+      end
+    end
+  end
+end
+

--- a/test/fixtures/cookbooks/f5_test/recipes/test_create_vip_name.rb
+++ b/test/fixtures/cookbooks/f5_test/recipes/test_create_vip_name.rb
@@ -1,0 +1,6 @@
+f5_vip 'myvip' do
+  address 'github.com'
+  port '80'
+  protocol 'PROTOCOL_TCP'
+  pool 'reallybasic'
+end


### PR DESCRIPTION
It would be nice to be able to get IP management out of Chef and into
something that's good at it, such as DNS.

Now you can create a vip such as

```Ruby
f5_vip 'foo' do
  address "origin-#{node.chef_environment}.example.com"
  ...
end
```

And it'll create the VIP with the resolved address, but only if the
resolution succeeds.

I'm positive there are some untouched corner cases, such as if you have
multiple A records. Or if you change the address, this may not react
well. However for the base case, this seems to work well. We've been
using this method for several months now, and I'm moving the code to
the resource itself.