### PR TITLE
allow optional naming differentiation between f5 and chef

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,32 @@ NOTE: these matches verify only the presence (or absence via `expect(chef_run).t
 
 The matchers cannot be used to validate whether convergence of an  `f5_pool` or `f5_vip` resource took place.
 
+NOTE: Due to [this issue](https://github.com/chefspec/chefspec/issues/703) you can't test multiple calls to a resource in chefspec if the resource name is the same.
+All resources have an optional `<RESOURCE_NAME>_name` attribute that you can use to override the chef resource's name. E.g. 
+```ruby
+f5_pool 'pool_name_create' do 
+  pool_name 'pool_name'
+  monitor 'tcp'
+end
+
+f5_pool 'pool_name_add_node1' do 
+  pool_name 'pool_name'
+  host 'node1'
+  ip '1.2.3.4'
+  port 443
+end
+
+f5_pool 'pool_name_add_node2' do 
+  pool_name 'pool_name'
+  host 'node2'
+  ip '1.2.3.5'
+  port 443
+end
+```
+
+In the above example, if `pool_name` wasn't specified then the resource name would have to be `pool_name` for each call to `f5_pool`. This would work as expected in chef but chefspec would only register the
+last invocation of `f5_pool`. By using the `pool_name` resource the chef resource can be uniquely named and therefore tested.  
+
 ## Testing this cookbook
 
 Run `bundle exec rake test` to run the chefspec tests.

--- a/resources/irule.rb
+++ b/resources/irule.rb
@@ -1,4 +1,5 @@
 property :name, String
+property :irule_name, [NilClass, String], default: nil
 property :definition, String
 property :load_balancer, String, regex: /.*/, default: 'default'
 property :lb_host, String
@@ -7,25 +8,29 @@ property :lb_password, String
 
 action :create do
   load_f5_gem
+  actual_irule_name = new_resource.irule_name || new_resource.name
   irule = ChefF5::IRule.new(node, new_resource, new_resource.load_balancer)
 
-  if irule.is_missing?(new_resource.name)
-    converge_by "Create IRule #{new_resource.name}" do
-      irule.create(new_resource.name, new_resource.definition)
+  if irule.is_missing?(actual_irule_name)
+    converge_by "Create IRule #{actual_irule_name}" do
+      irule.create(actual_irule_name, new_resource.definition)
       return
     end
   end
 
-  if irule.definition_changed?(new_resource.name, new_resource.definition)
-    converge_by "Update definition of IRule #{new_resource.name}" do
-      irule.update_definition(new_resource.name, new_resource.definition)
+  if irule.definition_changed?(actual_irule_name, new_resource.definition)
+    converge_by "Update definition of IRule #{actual_irule_name}" do
+      irule.update_definition(actual_irule_name, new_resource.definition)
     end
   end
 end
 
 action :destroy do
-  unless irule.is_missing?(new_resource.name)
-    converge_by "Destroy IRule #{new_resource.name}" do
+  actual_irule_name = new_resource.irule_name || new_resource.name
+  irule = ChefF5::IRule.new(node, new_resource, new_resource.load_balancer)
+
+  unless irule.is_missing?(actual_irule_name)
+    converge_by "Destroy IRule #{actual_irule_name}" do
       irule.destroy(name)
     end
   end

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -1,3 +1,4 @@
+property :pool_name, [NilClass, String], default: nil
 property :host, String, regex: /.*/
 property :ip, String, regex: /.*/
 property :port, [String, Integer], regex: /^(\*|\d+)$/
@@ -10,15 +11,16 @@ property :lb_password, String
 property :enabled_status, [:manual, :enabled, :disabled], default: node['f5']['enabled_status']
 
 create_node = proc do
+  actual_pool_name = new_resource.pool_name || new_resource.name
   if @f5.node_is_missing?(new_resource.host)
     converge_by("Add node #{new_resource.host}") do
       @f5.add_node(new_resource.host, new_resource.ip)
     end
   end
 
-  if @f5.pool_is_missing_node?(new_resource.name, new_resource.host)
-    converge_by("Add #{new_resource.host} to pool #{new_resource.name}") do
-      @f5.add_node_to_pool(new_resource.name, new_resource.host, new_resource.port)
+  if @f5.pool_is_missing_node?(actual_pool_name, new_resource.host)
+    converge_by("Add #{new_resource.host} to pool #{actual_pool_name}") do
+      @f5.add_node_to_pool(actual_pool_name, new_resource.host, new_resource.port)
     end
   end
   if new_resource.enabled_status != :manual
@@ -36,24 +38,25 @@ create_node = proc do
 end
 
 create_pool = proc do
-  if @f5.pool_is_missing?(new_resource.name)
-    converge_by("Create pool #{new_resource.name}") do
-      @f5.create_pool(new_resource.name)
+  actual_pool_name = new_resource.pool_name || new_resource.name
+  if @f5.pool_is_missing?(actual_pool_name)
+    converge_by("Create pool #{actual_pool_name}") do
+      @f5.create_pool(actual_pool_name)
     end
   end
 
   if new_resource.monitor
-    if @f5.pool_is_missing_monitor?(new_resource.name, new_resource.monitor)
-      converge_by("Add monitor #{new_resource.monitor} to pool #{new_resource.name}") do
+    if @f5.pool_is_missing_monitor?(actual_pool_name, new_resource.monitor)
+      converge_by("Add monitor #{new_resource.monitor} to pool #{actual_pool_name}") do
         begin
-          @f5.add_monitor(new_resource.name, new_resource.monitor)
+          @f5.add_monitor(actual_pool_name, new_resource.monitor)
         rescue StandardError => e
           Chef::Log.info("Adding monitor #{new_resource.monitor} failed. Ensure it exists.")
           Chef::Log.info(e.inspect)
         end
       end
     else
-      Chef::Log.debug("#{new_resource.name} already has monitor #{new_resource.monitor}")
+      Chef::Log.debug("#{actual_pool_name} already has monitor #{new_resource.monitor}")
     end
   end
 end

--- a/resources/vip.rb
+++ b/resources/vip.rb
@@ -1,3 +1,4 @@
+property :vip_name, [NilClass, String], default: nil
 property :address, String, regex: /.*/
 property :port, [Integer, String], regex: /^(\*|\d+)$/
 property :protocol, String, regex: /^[A-Z_]+$/, default: 'PROTOCOL_TCP'
@@ -26,82 +27,83 @@ end
 
 action :create do
   load_f5_gem
+  actual_vip_name = new_resource.vip_name || new_resource.name
   vip = ChefF5::VIP.new(node, new_resource, new_resource.load_balancer)
   ip = resolve_ip(new_resource.address)
 
   next if ip.nil?
 
-  if vip.vip_is_missing?(new_resource.name)
-    converge_by("Create vip #{new_resource.name}") do
-      vip.create_vip(new_resource.name, ip, new_resource.port, new_resource.protocol)
-      Chef::Log.info("#{new_resource} created vip #{new_resource.name} at #{ip}:#{new_resource.port}/#{new_resource.protocol}")
+  if vip.vip_is_missing?(actual_vip_name)
+    converge_by("Create vip #{actual_vip_name}") do
+      vip.create_vip(actual_vip_name, ip, new_resource.port, new_resource.protocol)
+      Chef::Log.info("#{new_resource} created vip #{actual_vip_name} at #{ip}:#{new_resource.port}/#{new_resource.protocol}")
     end
   end
 
-  if vip.vip_default_pool(new_resource.name) != new_resource.pool
-    vip.set_vip_pool(new_resource.name, new_resource.pool)
+  if vip.vip_default_pool(actual_vip_name) != new_resource.pool
+    vip.set_vip_pool(actual_vip_name, new_resource.pool)
   end
 
   if new_resource.client_ssl_profile
-    unless vip.has_client_ssl_profile?(new_resource.name, new_resource.client_ssl_profile)
-      converge_by("Add client ssl profile '#{new_resource.client_ssl_profile}' to '#{new_resource.name}'") do
-        vip.add_client_ssl_profile(new_resource.name, new_resource.client_ssl_profile)
-        Chef::Log.info("Added client ssl profile '#{new_resource.client_ssl_profile}' to '#{new_resource.name}'")
+    unless vip.has_client_ssl_profile?(actual_vip_name, new_resource.client_ssl_profile)
+      converge_by("Add client ssl profile '#{new_resource.client_ssl_profile}' to '#{actual_vip_name}'") do
+        vip.add_client_ssl_profile(actual_vip_name, new_resource.client_ssl_profile)
+        Chef::Log.info("Added client ssl profile '#{new_resource.client_ssl_profile}' to '#{actual_vip_name}'")
       end
     end
   end
 
   if new_resource.server_ssl_profile
-    unless vip.has_server_ssl_profile?(new_resource.name, new_resource.server_ssl_profile)
-      converge_by("Add server ssl profile '#{new_resource.server_ssl_profile}' to '#{new_resource.name}'") do
-        vip.add_server_ssl_profile(new_resource.name, new_resource.server_ssl_profile)
-        Chef::Log.info("Added server ssl profile '#{new_resource.server_ssl_profile}' to '#{new_resource.name}'")
+    unless vip.has_server_ssl_profile?(actual_vip_name, new_resource.server_ssl_profile)
+      converge_by("Add server ssl profile '#{new_resource.server_ssl_profile}' to '#{actual_vip_name}'") do
+        vip.add_server_ssl_profile(actual_vip_name, new_resource.server_ssl_profile)
+        Chef::Log.info("Added server ssl profile '#{new_resource.server_ssl_profile}' to '#{actual_vip_name}'")
       end
     end
   end
 
   http_profile = new_resource.http_profile
-  existing_profile_name = vip.has_any_http_profile?(new_resource.name)
+  existing_profile_name = vip.has_any_http_profile?(actual_vip_name)
   if http_profile
     if http_profile == :none
-      converge_by("Removing HTTP profile #{existing_profile_name} from #{new_resource.name}") do
-        vip.remove_http_profile(new_resource.name, existing_profile_name)
+      converge_by("Removing HTTP profile #{existing_profile_name} from #{actual_vip_name}") do
+        vip.remove_http_profile(actual_vip_name, existing_profile_name)
       end
-    elsif !vip.has_http_profile?(new_resource.name, http_profile)
-      converge_by "Set HTTP profile for #{new_resource.name} to #{http_profile}" do
-        vip.set_http_profile(new_resource.name, http_profile, existing_profile_name)
+    elsif !vip.has_http_profile?(actual_vip_name, http_profile)
+      converge_by "Set HTTP profile for #{actual_vip_name} to #{http_profile}" do
+        vip.set_http_profile(actual_vip_name, http_profile, existing_profile_name)
       end
     end
   end
 
   if new_resource.enforced_firewall_policy != :manual
-    current_enforced_firewall_policy = vip.vip_enforced_firewall_policy(new_resource.name)
+    current_enforced_firewall_policy = vip.vip_enforced_firewall_policy(actual_vip_name)
     unless current_enforced_firewall_policy == new_resource.enforced_firewall_policy
       if vip.firewall_policy_missing?(new_resource.enforced_firewall_policy)
         raise "Firewall policy #{new_resource.enforced_firewall_policy} does not exist"
       end
-      converge_by("Set enforced firewall policy on '#{new_resource.name}' to '#{new_resource.enforced_firewall_policy}'") do
-        vip.set_enforced_firewall_policy(new_resource.name, new_resource.enforced_firewall_policy)
-        Chef::Log.info("Set enforced firewall policy on '#{new_resource.name}' to '#{new_resource.enforced_firewall_policy}'")
+      converge_by("Set enforced firewall policy on '#{actual_vip_name}' to '#{new_resource.enforced_firewall_policy}'") do
+        vip.set_enforced_firewall_policy(actual_vip_name, new_resource.enforced_firewall_policy)
+        Chef::Log.info("Set enforced firewall policy on '#{actual_vip_name}' to '#{new_resource.enforced_firewall_policy}'")
       end
     end
   end
 
   if new_resource.staged_firewall_policy != :manual
-    current_staged_firewall_policy = vip.vip_staged_firewall_policy(new_resource.name)
+    current_staged_firewall_policy = vip.vip_staged_firewall_policy(actual_vip_name)
     unless current_staged_firewall_policy == new_resource.staged_firewall_policy
       if vip.firewall_policy_missing?(new_resource.staged_firewall_policy)
         raise "Firewall policy #{new_resource.staged_firewall_policy} does not exist"
       end
-      converge_by("Set staged firewall policy on '#{new_resource.name}' to '#{new_resource.staged_firewall_policy}'") do
-        vip.set_staged_firewall_policy(new_resource.name, new_resource.staged_firewall_policy)
-        Chef::Log.info("Set staged firewall policy on '#{new_resource.name}' to '#{new_resource.staged_firewall_policy}'")
+      converge_by("Set staged firewall policy on '#{actual_vip_name}' to '#{new_resource.staged_firewall_policy}'") do
+        vip.set_staged_firewall_policy(actual_vip_name, new_resource.staged_firewall_policy)
+        Chef::Log.info("Set staged firewall policy on '#{actual_vip_name}' to '#{new_resource.staged_firewall_policy}'")
       end
     end
   end
 
   if new_resource.snat_pool != :manual
-    current_snat_pool = vip.get_snat_pool(new_resource.name)
+    current_snat_pool = vip.get_snat_pool(actual_vip_name)
 
     unless current_snat_pool == new_resource.snat_pool
 
@@ -109,7 +111,7 @@ action :create do
                   " '#{current_snat_pool}' to"\
                   " '#{new_resource.snat_pool}'") do
 
-        vip.set_snat_pool(new_resource.name, new_resource.snat_pool)
+        vip.set_snat_pool(actual_vip_name, new_resource.snat_pool)
 
         Chef::Log.info("Changed server source address translation from"\
                     " '#{current_snat_pool}' to"\
@@ -117,14 +119,14 @@ action :create do
       end
     end
   end
-  added, changed, removed, target = vip.irules_changed?(new_resource.name, new_resource.irules)
+  added, changed, removed, target = vip.irules_changed?(actual_vip_name, new_resource.irules)
   unless [added, changed, removed].all? { |l| l.empty? }
-    msg = "Update IRules for #{new_resource.name}; "\
+    msg = "Update IRules for #{actual_vip_name}; "\
       "The following rules changed: #{changed.join ', '}."\
       "The following rules have been added: #{added.to_a.join ', '}"\
       "The following rules have been removed: #{removed.to_a.join ', '}"
     converge_by msg do
-      vip.update_irules(new_resource.name, target, added, changed, removed)
+      vip.update_irules(actual_vip_name, target, added, changed, removed)
     end
   end
 end


### PR DESCRIPTION
Due to this issue: https://github.com/chefspec/chefspec/issues/703 you can't test multiple calls to a resource in chefspec if the name is the same. This PR allows you to explicitly declare the F5 resource name separately from the chef resource name, allowing the chef resource name to be unique. 