### PR TITLE
Allow to specify partitions in resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.4.13
+Add handling the api_path to properly manage partitions.
 # 0.2.2
 Bugfix for the last version
 

--- a/libraries/base_client.rb
+++ b/libraries/base_client.rb
@@ -1,10 +1,11 @@
 module ChefF5
   class BaseClient
 
-    def initialize(node, resource, load_balancer)
+    def initialize(node, resource, load_balancer, partition)
       @node = node
       @resource = resource
       @load_balancer = load_balancer
+      @partition = partition
 
       # local module aliases reduce repetetive call chains
       @ProfileContextType = F5::Icontrol::LocalLB::ProfileContextType
@@ -23,7 +24,7 @@ module ChefF5
       if key =~ %r{^/} || key.to_s.empty?
         key
       else
-        "/Common/#{key}"
+        "/#{@partition}/#{key}"
       end
     end
 
@@ -37,6 +38,8 @@ module ChefF5
           password: credentials[:password]
         )
       end
+      @api.System.Session.set_active_folder(folder: "/#{@partition}")
+      @api
     end
   end
 end

--- a/libraries/chef_f5.rb
+++ b/libraries/chef_f5.rb
@@ -59,6 +59,7 @@ module ChefF5
     end
 
     def pool_is_missing?(name)
+      Chef::Log.warn "Folder is: #{api.System.Session.get_active_folder}"
       response = api.LocalLB.Pool.get_list
 
       return true if response[:item].nil?

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sean@ertw.com'
 license          'MIT'
 description      'Resources for managing an F5 BigIP load balancer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.12'
+version          '0.4.13'
 
 %w(ubuntu debian redhat centos suse opensuse opensuseleap scientific oracle amazon windows).each do |os|
   supports os

--- a/resources/irule.rb
+++ b/resources/irule.rb
@@ -5,11 +5,12 @@ property :load_balancer, String, regex: /.*/, default: 'default'
 property :lb_host, String
 property :lb_username, String
 property :lb_password, String
+property :partition, String, default: '/Common/'
 
 action :create do
   load_f5_gem
   actual_irule_name = new_resource.irule_name || new_resource.name
-  irule = ChefF5::IRule.new(node, new_resource, new_resource.load_balancer)
+  irule = ChefF5::IRule.new(node, new_resource, new_resource.load_balancer, new_resource.partition)
 
   if irule.is_missing?(actual_irule_name)
     converge_by "Create IRule #{actual_irule_name}" do
@@ -27,7 +28,7 @@ end
 
 action :destroy do
   actual_irule_name = new_resource.irule_name || new_resource.name
-  irule = ChefF5::IRule.new(node, new_resource, new_resource.load_balancer)
+  irule = ChefF5::IRule.new(node, new_resource, new_resource.load_balancer, new_resource.partition)
 
   unless irule.is_missing?(actual_irule_name)
     converge_by "Destroy IRule #{actual_irule_name}" do

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -13,13 +13,14 @@ property :load_balancer, String, regex: /.*/, default: 'default'
 property :lb_host, String
 property :lb_username, String
 property :lb_password, String
+property :partition, String, default: '/Common/'
 
 
 
 action :create do
   load_f5_gem
   actual_monitor_name = new_resource.monitor_name || new_resource.name
-  monitor = ChefF5::Monitor.new(node, new_resource, new_resource.load_balancer)
+  monitor = ChefF5::Monitor.new(node, new_resource, new_resource.load_balancer, new_resource.partition)
   if monitor.monitor_is_missing?(actual_monitor_name)
     converge_by "Create monitor template #{actual_monitor_name}" do
       monitor.create_monitor(actual_monitor_name, **f5_attributes)
@@ -60,7 +61,7 @@ end
 action :destroy do
   load_f5_gem
   actual_monitor_name = new_resource.monitor_name || new_resource.name
-  monitor = ChefF5::Monitor.new(node, new_resource, new_resource.load_balancer)
+  monitor = ChefF5::Monitor.new(node, new_resource, new_resource.load_balancer, new_resource.partition)
   unless monitor.monitor_is_missing?(actual_monitor_name)
     converge_by "Deleting monitor template #{actual_monitor_name}" do
       monitor.delete_monitor(actual_monitor_name)

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -9,6 +9,7 @@ property :load_balancer, String, regex: /.*/, default: 'default'
 property :lb_host, String
 property :lb_username, String
 property :lb_password, String
+property :partition, String, default: '/Common/'
 property :enabled_status, [:manual, :enabled, :disabled], default: node['f5']['enabled_status']
 
 create_node = proc do
@@ -88,7 +89,7 @@ end
 
 action :create do
   load_f5_gem
-  @f5 = ChefF5::Client.new(node, new_resource, new_resource.load_balancer)
+  @f5 = ChefF5::Client.new(node, new_resource, new_resource.load_balancer, new_resource.partition)
 
   instance_eval(&create_pool)
 
@@ -97,7 +98,7 @@ end
 
 action :add do
   load_f5_gem
-  @f5 = ChefF5::Client.new(node, new_resource, new_resource.load_balancer)
+  @f5 = ChefF5::Client.new(node, new_resource, new_resource.load_balancer, new_resource.partition)
 
   instance_eval(&create_node)
 end

--- a/resources/vip.rb
+++ b/resources/vip.rb
@@ -7,6 +7,7 @@ property :load_balancer, String, regex: /.*/, default: 'default'
 property :lb_host, String
 property :lb_username, String
 property :lb_password, String
+property :partition, String, default: '/Common/'
 property :client_ssl_profile, String
 property :server_ssl_profile, String
 property :snat_pool, [:manual, :none, :automap, String], default: :manual
@@ -28,7 +29,7 @@ end
 action :create do
   load_f5_gem
   actual_vip_name = new_resource.vip_name || new_resource.name
-  vip = ChefF5::VIP.new(node, new_resource, new_resource.load_balancer)
+  vip = ChefF5::VIP.new(node, new_resource, new_resource.load_balancer, new_resource.partition)
   ip = resolve_ip(new_resource.address)
 
   next if ip.nil?


### PR DESCRIPTION
To be able to properly create resources (mostly pools and nodes) in a specific partition different than Common.

By default Common is the partition used to get_list of pools and nodes. This patch fix that.

(Next pull request include this change and various style and test fixes to math actual cookstyle linting)